### PR TITLE
Exclude epel testing on centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Requirements
 - Chef 12.0 or later
 
 ### Cookbooks
-  
+
 - `yum-epel` = 0.7.0
 
 Recipes
@@ -34,7 +34,7 @@ Recipes
 
 This would install NetData on supported platforms. At the moment this product does not have any distribution packages and only supported installation method it to compile sources.
 
-NetData cookbook will install required dependencies and after compilation succeedis those deps will be removed, except those packages that already were installed on the server prior to chef run.
+NetData cookbook will install required dependencies and after compilation succeeds those deps will be removed, except those packages that already were installed on the server prior to chef run.
 
 ## Usage
 
@@ -63,4 +63,3 @@ Just include `netdata` in your node's `run_list`
 ## License and Authors
 
 Authors: Sergio Pena <sergio.pena@abiquo.com>
-

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,11 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-case node['platform_family'] 
-when 'rhel', 'redhat', 'centos', 'amazon', 'scientific', 'oracle' 
-	node.default['yum']['epel-testing']['enabled'] = true
-	node.default['yum']['epel-testing']['managed'] = true
-	include_recipe 'yum-epel'
+case node['platform_family']
+when 'rhel', 'redhat', 'centos', 'amazon', 'scientific', 'oracle'
+	if node['platform_version'] =~ /^6/
+		node.default['yum']['epel-testing']['enabled'] = true
+		node.default['yum']['epel-testing']['managed'] = true
+		include_recipe 'yum-epel'
+	end
 when 'ubuntu','debian'
 	true
 else

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,68 @@
+# Cookbook Name:: netdata
+# Specs:: default_spec
+#
+# Copyright 2016, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'netdata::default' do
+
+	yum_repo_platforms = {
+		'centos' => ['6.7']
+	}
+
+  yum_repo_platforms.each do |platform, versions|
+
+		describe platform do
+
+			versions.each do |version|
+
+				describe version do
+
+	        let(:chef_run) { ChefSpec::SoloRunner.new(platform: platform, version: version).converge(described_recipe) }
+
+          it "includes the yum-epel recipe" do
+      		  expect(chef_run).to include_recipe('yum-epel')
+	        end
+
+				end
+		  end
+		end
+	end
+
+  no_yum_repo_platforms = {
+		'centos' => ['7.2.1511'],
+		'ubuntu' => ['14.04']
+	}
+
+  no_yum_repo_platforms.each do |platform, versions|
+
+		describe platform do
+
+			versions.each do |version|
+
+				describe version do
+
+	        let(:chef_run) { ChefSpec::SoloRunner.new(platform: platform, version: version).converge(described_recipe) }
+
+          it "does not include the yum-epel recipe" do
+      		  expect(chef_run).to_not include_recipe('yum-epel')
+	        end
+
+				end
+		  end
+		end
+	end
+end


### PR DESCRIPTION
The epel-testing repository is required for autogen which is included on RHEL based distributions from version 7 onwards.
As such we do not need to run the yum-epel recipe for those versions thus avoiding some unexpected behaviours.