### PR TITLE
Allow git repo configuration via node attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Recipes
 
 ### netdata::default
 
-This would install NetData on supported platforms. At the moment this product does not have any distribution packages and only supported installation method it to compile sources.
+This would install NetData on supported platforms. At the moment this product does not have any distribution packages and the only supported installation method is to compile sources.
 
 NetData cookbook will install required dependencies and after compilation succeeds those deps will be removed, except those packages that already were installed on the server prior to chef run.
 
@@ -50,6 +50,11 @@ Just include `netdata` in your node's `run_list`
   ]
 }
 ```
+
+## Attributes
+
+- `node['netdata']['source']['git_repository']` - Netdata git repository. Defaults to https://github.com/firehol/netdata.git
+- `node['netdata']['source']['git_revision']` - Netdata repository git reference. Can be a tag, branch or master. Defaults to master.
 
 ## Contributing
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,7 @@
+# Netdata source repository
+default['netdata']['source']['git_repository'] = 'https://github.com/firehol/netdata.git'
+
+# Netdata source repository git reference.
+# Can be a tag, branch or master.
+# Defaults to master.
+default['netdata']['source']['git_revision'] = 'master'

--- a/recipes/install_netdata.rb
+++ b/recipes/install_netdata.rb
@@ -25,8 +25,8 @@ when 'rhel', 'redhat', 'centos', 'amazon', 'scientific', 'oracle'
 	end
 
 	git "/tmp/netdata" do
-		repository "https://github.com/firehol/netdata.git"
-		reference "master"
+		repository node['netdata']['source']['git_repository']
+		reference node['netdata']['source']['git_revision']
 		action :sync
 		notifies :run, 'execute[install]', :immediately
 	end

--- a/spec/install_netdata_spec.rb
+++ b/spec/install_netdata_spec.rb
@@ -32,6 +32,27 @@ describe 'netdata::install_netdata' do
 		}
 	}
 
+	describe 'git configuration' do
+
+    let(:git_reference) { '1.3.0' }
+		let(:git_repository) { 'https://github.com/random_dude/netdata.git' }
+		let(:chef_run) {
+			ChefSpec::SoloRunner.new(platform: 'centos', version: '6.7') do |node|
+				node.normal['netdata']['source']['git_repository'] = git_repository
+				node.normal['netdata']['source']['git_revision'] = git_reference
+			end.converge(described_recipe)
+		}
+
+		it 'uses a configurable git reference' do
+			expect(chef_run).to sync_git("/tmp/netdata").with(reference: git_reference)
+		end
+
+		it 'uses a configurable git repository' do
+			expect(chef_run).to sync_git("/tmp/netdata").with(repository: git_repository)
+		end
+
+	end
+
   platform_check.each do |platform, options|
 
 		describe platform do
@@ -49,7 +70,7 @@ describe 'netdata::install_netdata' do
 	        end
 
         	it 'clones github repo on /tmp folder' do
-	        	expect(chef_run).to sync_git("/tmp/netdata")
+            expect(chef_run).to sync_git("/tmp/netdata").with(reference: 'master')
         	end
 
         	it 'notifies the installer execution' do


### PR DESCRIPTION
Allow users to configure the git repository and reference when installing netdata. Useful for production environments when stabler versions are enforced.