### PR TITLE
Install python mysql module dependencies whenever necessary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Just include `netdata` in your node's `run_list`
 - `node['netdata']['source']['git_repository']` - Netdata git repository. Defaults to https://github.com/firehol/netdata.git
 - `node['netdata']['source']['git_revision']` - Netdata repository git reference. Can be a tag, branch or master. Defaults to master.
 
+- `node['netdata']['plugins']['python']['mysql']['enabled']` - False by default. If set to true installs all needed python dependencies to connect to MySQL.
+
 ## Contributing
 
 1. Fork the repository on Github

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,11 @@ default['netdata']['source']['git_repository'] = 'https://github.com/firehol/net
 # Can be a tag, branch or master.
 # Defaults to master.
 default['netdata']['source']['git_revision'] = 'master'
+
+########################################################################
+# Python plugin configuration
+########################################################################
+# Enabled/Disable mysql module
+# If set to true will also install all necessary dependencies
+# Defaults to false
+default['netdata']['plugins']['python']['mysql']['enabled'] = false

--- a/recipes/install_netdata.rb
+++ b/recipes/install_netdata.rb
@@ -18,7 +18,11 @@
 case node['platform_family']
 when 'rhel', 'redhat', 'centos', 'amazon', 'scientific', 'oracle'
 
-	%w{zlib-devel libuuid-devel libmnl-devel gcc make git autoconf autogen automake pkgconfig}.each do |pkg|
+	runtime_dependencies = %w{zlib-devel libuuid-devel libmnl-devel gcc make git autoconf autogen automake pkgconfig}
+	if node['netdata']['plugins']['python']['mysql']['enabled']
+		runtime_dependencies << 'MySQL-python'
+	end
+	runtime_dependencies.each do |pkg|
 		package pkg do
 			action :install
 		end
@@ -45,7 +49,12 @@ when 'rhel', 'redhat', 'centos', 'amazon', 'scientific', 'oracle'
 		end
 	end
 when 'ubuntu','debian'
-	%w{zlib1g-dev uuid-dev libmnl-dev gcc make git autoconf autogen automake pkg-config}.each do |pkg|
+
+	runtime_dependencies = %w{zlib1g-dev uuid-dev libmnl-dev gcc make git autoconf autogen automake pkg-config}
+	if node['netdata']['plugins']['python']['mysql']['enabled']
+		runtime_dependencies << 'python-mysqldb'
+	end
+	runtime_dependencies.each do |pkg|
 		package pkg do
 			action :install
 		end

--- a/spec/install_netdata_spec.rb
+++ b/spec/install_netdata_spec.rb
@@ -23,12 +23,14 @@ describe 'netdata::install_netdata' do
 		'centos' => {
 			versions: ['6.7'],
 			install_packages: %w{zlib-devel libuuid-devel libmnl-devel gcc make git autoconf autogen automake pkgconfig},
-			log_packages: %w{gcc make git autoconf autogen automake pkgconfig}
+			log_packages: %w{gcc make git autoconf autogen automake pkgconfig},
+			mysql_packages: %w{MySQL-python}
 		},
 		'ubuntu' => {
 			versions: ['14.04'],
 			install_packages: %w{zlib1g-dev uuid-dev libmnl-dev gcc make git autoconf autogen automake pkg-config},
-			log_packages: %w{gcc make git autoconf autogen automake pkg-config}
+			log_packages: %w{gcc make git autoconf autogen automake pkg-config},
+			mysql_packages: %w{python-mysqldb}
 		}
 	}
 
@@ -98,6 +100,34 @@ describe 'netdata::install_netdata' do
 	      	  	expect(log).to subscribe_to("package[#{pkg}]").on(:write)
         		end
 					end
+				end
+
+				describe version do
+
+					describe 'python plugin' do
+
+					  describe 'mysql module' do
+
+							let(:chef_run) { ChefSpec::SoloRunner.new(platform: platform, version: version) }
+
+							options[:mysql_packages].each do |pkg|
+
+								it "does not install #{pkg} package dependency by default" do
+									chef_run.converge(described_recipe)
+									expect(chef_run).to_not install_package(pkg)
+								end
+
+		      	  	it "installs the #{pkg} package dependency" do
+									chef_run.node.normal['netdata']['plugins']['python']['mysql']['enabled'] = true
+									chef_run.converge(described_recipe)
+									expect(chef_run).to install_package(pkg)
+		        		end
+			        end
+
+					  end
+
+					end
+
 				end
 		  end
 		end


### PR DESCRIPTION
The MySQL python module requires either MySQLdb or PyMySQL so the cookbook must ensure they are installed.

My concern here is that by default all modules are enabled but remain silent unless they are able to monitor something.

To avoid having to install unnecessary dependencies a chef attribute was created:
- ['netdata']['plugins']['python']['mysql']['enabled']

...which is set to false by default. On nodes that have MySQL installed users will need to set this to true which kinda makes sense because chances are they will also need to update the mysql.conf file as well.