### PR TITLE
Allow users to configure where chef clones the netdata repo to.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Just include `netdata` in your node's `run_list`
 
 - `node['netdata']['source']['git_repository']` - Netdata git repository. Defaults to https://github.com/firehol/netdata.git
 - `node['netdata']['source']['git_revision']` - Netdata repository git reference. Can be a tag, branch or master. Defaults to master.
+- `node['netdata']['source']['directory']` - Local directory where the netdata repo will be cloned. Defaults to /tmp/netdata but should be replaced because most UNIX system periodically clean the /tmp directory.
 
 - `node['netdata']['plugins']['python']['mysql']['enabled']` - False by default. If set to true installs all needed python dependencies to connect to MySQL.
 
@@ -69,7 +70,6 @@ Just include `netdata` in your node's `run_list`
 
 ## License and Authors
 
-Authors: 
+Authors:
 * Sergio Pena https://github.com/sergiopena
 * João Madureira https://github.com/jmadureira
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,11 @@ default['netdata']['source']['git_repository'] = 'https://github.com/firehol/net
 # Defaults to master.
 default['netdata']['source']['git_revision'] = 'master'
 
+# Local directory where the netdata repo will be cloned
+# Defaults to /tmp/netdata but should be replaced because most UNIX system
+# periodically clean the /tmp directory
+default['netdata']['source']['directory'] = '/tmp/netdata'
+
 ########################################################################
 # Python plugin configuration
 ########################################################################

--- a/recipes/install_netdata.rb
+++ b/recipes/install_netdata.rb
@@ -28,7 +28,7 @@ when 'rhel', 'redhat', 'centos', 'amazon', 'scientific', 'oracle'
 		end
 	end
 
-	git "/tmp/netdata" do
+	git node['netdata']['source']['directory'] do
 		repository node['netdata']['source']['git_repository']
 		reference node['netdata']['source']['git_revision']
 		action :sync
@@ -36,8 +36,8 @@ when 'rhel', 'redhat', 'centos', 'amazon', 'scientific', 'oracle'
 	end
 
 	execute 'install' do
-		cwd '/tmp/netdata'
-		command '/tmp/netdata/netdata-installer.sh --zlib-is-really-here --dont-wait'
+		cwd node['netdata']['source']['directory']
+		command "#{node['netdata']['source']['directory']}/netdata-installer.sh --zlib-is-really-here --dont-wait"
 		action :nothing
 	end
 
@@ -60,16 +60,16 @@ when 'ubuntu','debian'
 		end
 	end
 
-	git "/tmp/netdata" do
-		repository "https://github.com/firehol/netdata.git"
-		reference "master"
+	git node['netdata']['source']['directory'] do
+		repository node['netdata']['source']['git_repository']
+		reference node['netdata']['source']['git_revision']
 		action :sync
 		notifies :run, 'execute[install]', :immediately
 	end
 
 	execute 'install' do
-		cwd '/tmp/netdata'
-		command '/tmp/netdata/netdata-installer.sh --zlib-is-really-here --dont-wait'
+		cwd node['netdata']['source']['directory']
+		command "#{node['netdata']['source']['directory']}/netdata-installer.sh --zlib-is-really-here --dont-wait"
 		action :nothing
 	end
 


### PR DESCRIPTION
Most UNIX based system (not all apparently) clean up the /tmp directory periodically. As a consequence any rechef done after the cleanup fails.

This merge simply allows users to specify a different source directory.
I didn't change the default directory so it doesn't change any current behaviour.