### PR TITLE
Allow users to configure the bind rndc python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,33 @@ Just include `netdata` in your node's `run_list`
 
 ## Resources
 
+### netdata_bind_rndc_conf
+
+Configures the netdata python bind rndc module.
+
+Accepts the following attributes:
+
+- `conf_file` - Location of the netdata configuration file. Defaults to `/etc/netdata/python.d/bind_rndc.conf`.
+- `owner` - Owner of the configuration file. Defaults to `netdata`.
+- `group` - Group of the configuration file. Defaults to `netdata`.
+- `named_stats_path` - Location of the bind statistics file. Defaults to `nil` indicating that the default netdata location should be used.
+
+netdata_bind_rndc_conf 'customer_bind_config' do
+  named_stats_path 'custom path' #defaults to nil
+end
+```
+
+To test using `ChefSpec` you can use the provided matcher `configure_netdata_bind_rndc_module`.
+
+```ruby
+it 'does something' do
+  expect(chef_run.converge(described_recipe)).to configure_netdata_bind_rndc_module('customer_bind_config')
+end
+```
+
 ### netdata_nginx_conf
 
-Configures the netdata python nginx configuration.
+Configures the netdata python nginx module.
 
 ```ruby
 jobs_config = {

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ Accepts the following attributes:
 - `group` - Group of the configuration file. Defaults to `netdata`.
 - `named_stats_path` - Location of the bind statistics file. Defaults to `nil` indicating that the default netdata location should be used.
 
+```ruby
 netdata_bind_rndc_conf 'customer_bind_config' do
-  named_stats_path 'custom path' #defaults to nil
+  named_stats_path 'custom path'
 end
 ```
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -16,7 +16,12 @@
 # limitations under the License.
 
 if defined?(ChefSpec)
+  ChefSpec.define_matcher :netdata_bind_rndc_conf
   ChefSpec.define_matcher :netdata_nginx_conf
+
+  def configure_netdata_bind_rndc_module(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:netdata_bind_rndc_conf, :create, resource_name)
+  end
 
   def configure_netdata_nginx_module(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:netdata_nginx_conf, :create, resource_name)

--- a/resources/bind_rndc_conf.rb
+++ b/resources/bind_rndc_conf.rb
@@ -1,0 +1,39 @@
+# Cookbook Name:: netdata
+# Resources:: netdata_bind_rndc_conf
+#
+# Copyright 2016, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name :netdata_bind_rndc_conf
+
+default_action :create
+
+attribute :conf_file,        kind_of: String, default: '/etc/netdata/python.d/bind_rndc.conf'
+attribute :owner,            kind_of: String, default: 'netdata'
+attribute :group,            kind_of: String, default: 'netdata'
+attribute :named_stats_path, kind_of: String, default: nil
+
+action :create do
+  t = template new_resource.conf_file do
+    cookbook 'netdata'
+    source 'bind_rndc.conf.erb'
+    mode 0644
+    owner new_resource.owner
+    group new_resource.group
+    variables(
+      :named_stats_path => new_resource.named_stats_path
+    )
+  end
+  new_resource.updated_by_last_action(t.updated_by_last_action?)
+end

--- a/spec/bind_rndc_conf_spec.rb
+++ b/spec/bind_rndc_conf_spec.rb
@@ -1,0 +1,72 @@
+# Cookbook Name:: netdata
+# Specs:: bind_rdnc_conf_spec
+#
+# Copyright 2016, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'netdata_test::bind_rndc' do
+  let(:platform) { 'centos' }
+  let(:version) { '6.7' }
+  let(:file_path) { '/etc/netdata/python.d/bind_rndc.conf' }
+  let(:default_bind_rndc_config) {
+    {
+      :named_stats_path => '/custom/path'
+    }
+  }
+
+  describe 'python bind_rndc provider matcher' do
+    let(:chef_run) {
+      ChefSpec::SoloRunner.new(platform: platform, version: version) do |node|
+        node.normal['netdata']['plugins']['python']['bind_rndc']['config'] = default_bind_rndc_config
+      end
+    }
+
+    it 'configures bind_rndc' do
+      expect(chef_run.converge(described_recipe)).to configure_netdata_bind_rndc_module('default_bind_rndc_config').with(
+        :named_stats_path => '/custom/path'
+      )
+    end
+  end
+
+  describe 'python bind_rndc module' do
+    let(:chef_run) {
+      ChefSpec::SoloRunner.new(platform: platform, version: version, step_into: ['netdata_bind_rndc_conf']) do |node|
+        node.normal['netdata']['plugins']['python']['bind_rndc']['config'] = default_bind_rndc_config
+      end
+    }
+
+    it 'updates the configuration' do
+      expect(chef_run.converge(described_recipe)).to render_file(file_path)
+    end
+
+    it 'uses default configuration' do
+      expect(chef_run.converge(described_recipe)).to render_file(file_path).with_content { |content|
+        expect(content).to include('/custom/path')
+      }
+    end
+
+    it 'uses custom configuration' do
+      chef_run.node.normal['netdata']['plugins']['python']['bind_rndc']['config'] = {
+        :named_stats_path => '/etc/custom/path'
+      }
+      chef_run.converge(described_recipe)
+
+      expect(chef_run).to render_file(file_path).with_content { |content|
+        expect(content).to include('/etc/custom/path')
+      }
+    end
+  end
+end

--- a/templates/default/bind_rndc.conf.erb
+++ b/templates/default/bind_rndc.conf.erb
@@ -1,0 +1,111 @@
+# netdata python.d.plugin configuration for bind_rndc
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname     # the JOB's name as it will appear at the
+#                      # dashboard (by default is the job_name)
+#                      # JOBs sharing a name are mutually exclusive
+#     update_every: 1  # the JOB's data collection frequency
+#     priority: 60000  # the JOB's order on the dashboard
+#     retries: 5       # the JOB's number of restoration attempts
+#
+# Additionally to the above, bind_rndc also supports the following:
+#
+#     named_stats_path: 'path to named.stats'		# Default: '/var/log/bind/named.stats'
+#------------------------------------------------------------------------------------------------------------------
+# IMPORTANT Information
+#
+# BIND APPEND logs at EVERY RUN. Its NOT RECOMMENDED to set update_every below 30 sec.
+# STRONGLY RECOMMENDED to create a bind-rndc conf file for logrotate
+#
+# To set up your BIND to dump stats do the following:
+#
+# 1. add to 'named.conf.options' options {}:
+# statistics-file "/var/log/bind/named.stats";
+#
+# 2. Create bind/ directory in /var/log
+# cd /var/log/ && mkdir bind
+#
+# 3. Change owner of directory to 'bind' user
+# chown bind bind/
+#
+# 4. RELOAD (NOT restart) BIND
+# systemctl reload bind9.serice
+#
+# 5. Run as a root 'rndc stats' to dump (BIND will create named.stats in new directory)
+#
+#
+# To ALLOW NETDATA TO RUN 'rndc stats' change '/etc/bind/rndc.key' group to netdata
+# chown :netdata rndc.key
+#
+# The last BUT NOT least is to create bind-rndc.conf in logrotate.d/
+# The working one
+#  /var/log/bind/named.stats {
+#
+#     daily
+#     rotate 4
+#     compress
+#     delaycompress
+#     create 0644 bind bind
+#     missingok
+#     postrotate
+#         rndc reload > /dev/null
+#     endscript
+# }
+#
+# To test your logrotate conf file run as root:
+#
+# logrotate /etc/logrotate.d/bind-rndc -d (debug dry-run mode)
+# ------------------------------------------------------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+#
+<% if @named_stats_path %>
+local:
+ named_stats_path: '<%= @named_stats_path %>'
+<% end %>

--- a/test/fixtures/cookbooks/netdata_test/recipes/bind_rndc.rb
+++ b/test/fixtures/cookbooks/netdata_test/recipes/bind_rndc.rb
@@ -1,0 +1,3 @@
+netdata_bind_rndc_conf 'default_bind_rndc_config' do
+  named_stats_path node['netdata']['plugins']['python']['bind_rndc']['config']['named_stats_path']
+end


### PR DESCRIPTION
Add a new LWRP to update the bind python module.

At this stage only the location of the bind statistics file can be configured but additional configuration can be easily added later on.