### PR TITLE
Allow changes to the netdata.conf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,34 @@ Just include `netdata` in your node's `run_list`
 
 ## Attributes
 
+- `node['netdata']['user']` - Netdata user name. Since it is not possible to specify the user during installation do not change this FTTB. Defaults to netdata.
+- `node['netdata']['group']` - Netdata group name. Since it is not possible to specify the group during installation do not change this FTTB. Defaults to netdata.
+
 - `node['netdata']['source']['git_repository']` - Netdata git repository. Defaults to https://github.com/firehol/netdata.git
 - `node['netdata']['source']['git_revision']` - Netdata repository git reference. Can be a tag, branch or master. Defaults to master.
 - `node['netdata']['source']['directory']` - Local directory where the netdata repo will be cloned. Defaults to /tmp/netdata but should be replaced because most UNIX system periodically clean the /tmp directory.
 
 - `node['netdata']['plugins']['python']['mysql']['enabled']` - False by default. If set to true installs all needed python dependencies to connect to MySQL.
+
+- `node['netdata']['conf']` - Map to configure the netdata.conf file. Defaults to an empty map indicating that the netdata.conf should be left unchanged. Accepted configuration should be in the format `key => map`, for instance:
+
+```json
+{
+  "netdata": {
+    "conf": {
+      "global": {
+        "bind to": "localhost"
+      }
+    }
+  }
+}
+```
+... will create the following file:
+
+```
+[global]
+        bind to = localhost
+```
 
 ## Resources
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,11 @@
+# Netdata user name. Since it is not possible to specify the user during installation do not change this.
+# Defaults to netdata.
+default['netdata']['user'] = 'netdata'
+
+# Netdata group name. Since it is not possible to specify the group during installation do not change this.
+# Defaults to netdata.
+default['netdata']['group'] = 'netdata'
+
 # Netdata source repository
 default['netdata']['source']['git_repository'] = 'https://github.com/firehol/netdata.git'
 
@@ -10,6 +18,14 @@ default['netdata']['source']['git_revision'] = 'master'
 # Defaults to /tmp/netdata but should be replaced because most UNIX system
 # periodically clean the /tmp directory
 default['netdata']['source']['directory'] = '/tmp/netdata'
+
+########################################################################
+# Netdata configuration
+########################################################################
+
+# Map with attributes to add to the netdata.conf file.
+# Defaults to an empty map which will leave the default conf file unchanged.
+default['netdata']['conf'] = {}
 
 ########################################################################
 # Python plugin configuration

--- a/recipes/install_netdata.rb
+++ b/recipes/install_netdata.rb
@@ -75,14 +75,13 @@ else
 end
 
 # Update the netdata.conf if there's any configuration to include
-if node['netdata']['conf'].any?
-  template "/etc/netdata/netdata.conf" do
-    source "netdata.conf.erb"
-    mode 0664
-    owner node['netdata']['user']
-    group node['netdata']['group']
-    notifies :restart, "service[netdata]", :delayed
-  end
+template "/etc/netdata/netdata.conf" do
+  source "netdata.conf.erb"
+  mode 0664
+  owner node['netdata']['user']
+  group node['netdata']['group']
+  notifies :restart, "service[netdata]", :delayed
+  only_if { node['netdata']['conf'].any? }
 end
 
 service 'netdata' do

--- a/recipes/install_netdata.rb
+++ b/recipes/install_netdata.rb
@@ -73,3 +73,19 @@ when 'ubuntu', 'debian'
 else
   raise 'Unsupported platform family'
 end
+
+# Update the netdata.conf if there's any configuration to include
+if node['netdata']['conf'].any?
+  template "/etc/netdata/netdata.conf" do
+    source "netdata.conf.erb"
+    mode 0664
+    owner node['netdata']['user']
+    group node['netdata']['group']
+    notifies :restart, "service[netdata]", :delayed
+  end
+end
+
+service 'netdata' do
+  supports restart: true
+  action :nothing
+end

--- a/spec/install_netdata_spec.rb
+++ b/spec/install_netdata_spec.rb
@@ -80,6 +80,29 @@ describe 'netdata::install_netdata' do
           it 'does not run installer by default' do
             expect(chef_run).to_not run_execute('install')
           end
+
+          it 'does not restart service netdata' do
+            expect(chef_run).to_not restart_service('netdata')
+          end
+
+        end
+
+        describe version do
+          describe 'netdata.conf' do
+
+            it 'does not update the conf file if there are no configuration changes' do
+              chef_run = ChefSpec::SoloRunner.new(platform: platform, version: version).converge(described_recipe)
+              expect(chef_run).to_not render_file('/etc/netdata/netdata.conf')
+            end
+
+            it 'updates the conf file if there are configuration changes' do
+              chef_run = ChefSpec::SoloRunner.new(platform: platform, version: version) do |node|
+                node.normal['netdata']['conf']['global'] = { history: 3996 }
+              end.converge(described_recipe)
+              expect(chef_run).to render_file('/etc/netdata/netdata.conf')
+            end
+
+          end
         end
 
         describe version do

--- a/templates/default/netdata.conf.erb
+++ b/templates/default/netdata.conf.erb
@@ -1,0 +1,18 @@
+# netdata configuration
+#
+# You can download the latest version of this file, using:
+#
+#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+# or
+#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+#
+# You can uncomment and change any of the options below.
+# The value shown in the commented settings, is the default value.
+#
+<% node['netdata']['conf'].each do |key,attrs| %>
+[<%= key %>]
+<% attrs.each do |k,v| %>
+        <%= k %> = <%= v %>
+<% end %>
+
+<% end %>


### PR DESCRIPTION
Allow users to change the contents of the netdata.conf file by using the `node['netdata']['conf']` attribute.

This addresses #7.